### PR TITLE
Remove type declaration from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "xrandr-watcher",
   "version": "0.1.0",
   "description": "xrandr event watcher",
-  "type": "module",
   "main": "index.js",
   "scripts": {
     "start": "node --experimental-modules ./index.js ./example-handler.sh",


### PR DESCRIPTION
require() of ES modules is not supported. This is detected as an ES module because of this one line in package.json, which isn't serving any other purpose. This commit removes the line.